### PR TITLE
exclude node_modules from initial find

### DIFF
--- a/ash
+++ b/ash
@@ -107,7 +107,7 @@ fi
 # shellcheck disable=SC2120
 # Find all possible extensions in the $SOURCE_DIR directory
 map_extensions_anf_files() {
-  all_files=$(find "${SOURCE_DIR}" -type f -name '*' -not -path "./cdk.out/*") # $SOURCE_DIR comes from user input
+  all_files=$(find "${SOURCE_DIR}" \( -path '*/node_modules*' -prune -o -path '*/cdk.out*' -prune \) -o -type f -name '*') # $SOURCE_DIR comes from user input
   extenstions_found=()
   files_found=()
 


### PR DESCRIPTION
mapping extensions and files is unnecessary on node_modules folders. addresses https://github.com/aws-samples/automated-security-helper/issues/1

*Issue #, if available:* 1

*Description of changes:* exclude node_modules from initial `find` script


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
