### PR TITLE
Added OCI alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 utils/cfn-to-cdk/cfn_to_cdk/
+utils/cfn-to-cdk/cdk.out/


### PR DESCRIPTION
Added finch as an alternative for Docker Desktop via the -f flag

*Issue #, if available:*

N/A

*Description of changes:*
Added a new flag (`-f`) to use [finch](https://github.com/runfinch/finch) instead of docker as the OCI runner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
