### PR TITLE
Fix help text (ash -h)

### DIFF
--- a/ash
+++ b/ash
@@ -23,8 +23,6 @@ print_usage() {
   echo -e "\t--force                  Rebuild the Docker images of the scanning tools, to make sure software is up-to-date."
   echo -e "\t-q | --quiet             Don't print verbose text about the build process."
   echo -e "\t-c | --no-color          Don't print colorized output."
-
-  echo -e "\t-q | --quiet             Don't print verbose text about the build process"
   echo -e "\t-f | --finch             Use finch instead of docker to run the containerized tools.\n"
   echo -e "For more information please visit https://github.com/aws-samples/automated-security-helper"
 }


### PR DESCRIPTION
Argument "-q | --quiet" appeared twice in the help text.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
