### PR TITLE
Version 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-<a name="1.0.8-e-03May2023"></a>
+<a name="1.0.9-i-16May2023"></a>
+# 1.0.9-i-16May2023
+### Automated Security Helper
+
+* Changed YAML scanning (presumed CloudFormation templates) to look for CloudFormation template files explicitly, and excluding some well known folders
+added additional files that checkov knows how to scan to the list of CloudFormation templates (Dockerfiles, .gitlab-ci.yml)
+* Re-factored CDK scanning in several ways:
+    * Moved Python package install to the Dockerfile (container image build) so it's done once
+    * Removed code that doesn't do anything
+    * Added diagnostic information to report regarding the CDK version, Node version, and NPM packages installed.
+* Fixed Semgrep exit code
+
 # 1.0.8-e-03May2023
 ### Automated Security Helper
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-<a name="1.0.9-i-16May2023"></a>
-# 1.0.9-i-16May2023
+<a name="1.0.9-e-16May2023"></a>
+# 1.0.9-e-16May2023
 ### Automated Security Helper
 
 * Changed YAML scanning (presumed CloudFormation templates) to look for CloudFormation template files explicitly, and excluding some well known folders

--- a/ash
+++ b/ash
@@ -2,7 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 set -e
-VERSION=("1.0.8-e-03May2023")
+VERSION=("1.0.9-e-16May2023")
 OCI_RUNNER="docker"
 
 
@@ -31,7 +31,7 @@ print_usage() {
 GIT_EXTENSIONS=("git")
 PY_EXTENSIONS=("py" "pyc" "ipynb")
 INFRA_EXTENSIONS=("yaml" "yml" "tf" "json" "dockerfile")
-CFN_EXTENSIONS=("yaml" "yml" "json")
+CFN_EXTENSIONS=("yaml" "yml" "json" "template")
 JS_EXTENSIONS=("js")
 GRYPE_EXTENSIONS=("js" "py" "java" "go" "cs" "sh")
 
@@ -232,6 +232,7 @@ run_security_check() {
   exit ${RETURN_CODE}
 }
 
+validate_input
 
 IFS=$'\n' # Support directories with spaces, make the loop iterate over newline instead of space
 # Extract all zip files to temp dir before scanning
@@ -244,7 +245,6 @@ unset IFS
 
 all_files='' # Variable will be populated inside 'map_extensions_and_files' block
 
-validate_input
 map_extensions_and_files
 
 echo -e "ASH version $VERSION\n"

--- a/helper_dockerfiles/Dockerfile-cdk
+++ b/helper_dockerfiles/Dockerfile-cdk
@@ -9,11 +9,12 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y curl && \
+    apt-get install -y python3-venv && \
     rm -rf /var/lib/apt/lists/*
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+RUN npm install -g cdk
 RUN pip install --no-cache-dir --upgrade pip
-RUN npm install -g aws-cdk
-RUN python3 -m pip install -U aws-cdk-lib cdk-nag jinja2
+RUN python3 -m pip install -U aws-cdk-lib cdk-nag jinja2 constructs jsii
 WORKDIR /app
 
 CMD bash -C /utils/cdk-docker-execute.sh

--- a/utils/cfn-to-cdk/cfn_to_cdk/cfn_to_cdk_stack.py
+++ b/utils/cfn-to-cdk/cfn_to_cdk/cfn_to_cdk_stack.py
@@ -9,6 +9,6 @@ class CfnToCdkStack(cdk.Stack):
         super().__init__(scope, construct_id, **kwargs)
 
     
-        template0 = cfn_inc.CfnInclude(self, "/app/simple_s3.yaml",  
-                template_file="/app/simple_s3.yaml")
+        template0 = cfn_inc.CfnInclude(self, "/app/test.yaml",  
+                template_file="/app/test.yaml")
     

--- a/utils/grype-docker-execute.sh
+++ b/utils/grype-docker-execute.sh
@@ -41,7 +41,7 @@ echo -e "\n<<<<<< End Syft output <<<<<<\n" >>grype_report_result.txt
 
 echo -e "\n>>>>>> Begin Semgrep output >>>>>>\n" >>grype_report_result.txt
 
-semgrep --config=auto . >>grype_report_result.txt 2>&1
+semgrep --error --config=auto . >>grype_report_result.txt 2>&1
 CRC=$?
 RC=$(bumprc $RC $CRC)
 


### PR DESCRIPTION
* Changed YAML scanning (presumed CloudFormation templates) to look for CloudFormation template files explicitly, and excluding some well known folders
added additional files that checkov knows how to scan to the list of CloudFormation templates (Dockerfiles, .gitlab-ci.yml)
* Re-factored CDK scanning in several ways:
    * Moved Python package install to the Dockerfile (container image build) so it's done once
    * Removed code that doesn't do anything
    * Added diagnostic information to report regarding the CDK version, Node version, and NPM packages installed.
* Fixed Semgrep exit code